### PR TITLE
Fix white fringe on cutout textures (alpha bleed before BC compression)

### DIFF
--- a/shared/dxt_compress.c
+++ b/shared/dxt_compress.c
@@ -752,3 +752,73 @@ DLL_EXPORT void downsample_lanczos3(const uint8_t *src, int src_w, int src_h,
         }
     }
 }
+
+/* --------------------------------------------------------------------------
+ * Alpha bleed / edge-extend (in place)
+ *
+ * Fills the RGB of fully-transparent pixels with the average color of nearest
+ * opaque/already-filled neighbors, via a multi-pass flood. Without this,
+ * transparent pixels keep their (often white) RGB, which BC block-averaging and
+ * mipmap downsampling smear into cutout edges -> white fringe. Alpha is left
+ * untouched. Call this on the RGBA buffer BEFORE compression / downsampling.
+ * -------------------------------------------------------------------------- */
+DLL_EXPORT void alpha_bleed(uint8_t *rgba, int width, int height) {
+    int n = width * height;
+    if (n <= 0) return;
+
+    uint8_t *filled = (uint8_t *)malloc((size_t)n);
+    if (!filled) return;
+
+    int any_transparent = 0;
+    int i;
+    for (i = 0; i < n; i++) {
+        if (rgba[i * 4 + 3] != 0) {
+            filled[i] = 1;
+        } else {
+            filled[i] = 0;
+            any_transparent = 1;
+        }
+    }
+    if (!any_transparent) { free(filled); return; }
+
+    static const int DX[8] = { -1, 1, 0, 0, -1, 1, -1, 1 };
+    static const int DY[8] = { 0, 0, -1, 1, -1, -1, 1, 1 };
+
+    int max_passes = (width > height ? width : height);
+    int *newly = (int *)malloc(sizeof(int) * (size_t)n);
+    if (!newly) { free(filled); return; }
+
+    int pass;
+    for (pass = 0; pass < max_passes; pass++) {
+        int newly_count = 0;
+        int x, y, k;
+        for (y = 0; y < height; y++) {
+            for (x = 0; x < width; x++) {
+                int p = y * width + x;
+                if (filled[p]) continue;
+                int rs = 0, gs = 0, bs = 0, cnt = 0;
+                for (k = 0; k < 8; k++) {
+                    int nx = x + DX[k], ny = y + DY[k];
+                    if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+                    int np = ny * width + nx;
+                    if (filled[np]) {
+                        int o = np * 4;
+                        rs += rgba[o]; gs += rgba[o + 1]; bs += rgba[o + 2]; cnt++;
+                    }
+                }
+                if (cnt) {
+                    int o = p * 4;
+                    rgba[o]     = (uint8_t)(rs / cnt);
+                    rgba[o + 1] = (uint8_t)(gs / cnt);
+                    rgba[o + 2] = (uint8_t)(bs / cnt);
+                    newly[newly_count++] = p;
+                }
+            }
+        }
+        if (newly_count == 0) break;
+        for (i = 0; i < newly_count; i++) filled[newly[i]] = 1;
+    }
+
+    free(newly);
+    free(filled);
+}

--- a/shared/dxt_compress.py
+++ b/shared/dxt_compress.py
@@ -118,6 +118,14 @@ def _init_dll():
         ]
         _dll.decompress_bgra8.restype = None
 
+        # void alpha_bleed(uint8_t *rgba, int width, int height)  [in place]
+        # Optional: only present in DLLs built after the edge-extend fix.
+        try:
+            _dll.alpha_bleed.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
+            _dll.alpha_bleed.restype = None
+        except AttributeError:
+            pass
+
         _log("DLL loaded successfully - using FAST native compression")
         return _dll
     except Exception as e:
@@ -158,6 +166,18 @@ def native_decompress(data, width, height, fmt):
     else:
         return None
     return output.raw
+
+
+def alpha_bleed(rgba, width, height):
+    """Edge-extend transparent pixels' RGB from nearest opaque neighbors (kills
+    the white fringe on cutout textures). Native if the DLL exports it, else None
+    so callers fall back to the pure-Python implementation in tex_core."""
+    dll = _init_dll()
+    if dll is not None and hasattr(dll, 'alpha_bleed'):
+        buf = ctypes.create_string_buffer(bytes(rgba), len(rgba))
+        dll.alpha_bleed(buf, width, height)
+        return buf.raw[:len(rgba)]
+    return None
 
 
 def rgba_to_bgra(rgba, num_pixels):

--- a/shared/tex_core.py
+++ b/shared/tex_core.py
@@ -415,6 +415,12 @@ def rgba_to_tex_data(rgba, width, height, fmt, mipmaps=False, compressor=None):
 
     tex = TexFile(width, height, fmt, mipmaps)
 
+    # Edge-extend (alpha bleed) ONCE on the full-res image, before compression
+    # AND before mipmap downsampling, so neither the BC block-average nor the
+    # Lanczos downsample mixes transparent pixels' (often white) RGB into the
+    # edges. This removes the white fringe around cutout/alpha-tested textures.
+    rgba = _alpha_bleed(rgba, width, height)
+
     if not mipmaps:
         tex.data = _compress_level(rgba, width, height, fmt, compressor)
     else:
@@ -426,8 +432,75 @@ def rgba_to_tex_data(rgba, width, height, fmt, mipmaps=False, compressor=None):
     return tex
 
 
+def _alpha_bleed(rgba, width, height):
+    """Edge-extend (alpha bleed / dilation): fill the RGB of transparent pixels
+    with the color of the nearest opaque pixel.
+
+    Without this, fully-transparent pixels keep whatever RGB they had (often
+    white in GIMP). BC1/BC3 averages RGB across each 4x4 block — including those
+    transparent-but-white pixels — and mipmap downsampling mixes them in too, so
+    a white halo bleeds along cutout edges. Bleeding the edge color into the
+    transparent region removes the fringe; alpha is untouched.
+
+    Multi-pass flood: each pass copies color from any opaque/already-filled
+    neighbor into adjacent transparent pixels, until none remain (or it stalls).
+
+    Uses the native DLL implementation when available (fast); otherwise the pure
+    Python flood below.
+    """
+    try:
+        from dxt_compress import alpha_bleed as _native_bleed
+        native = _native_bleed(rgba, width, height)
+        if native is not None:
+            return native
+    except Exception:
+        pass
+
+    buf = bytearray(rgba)
+    # filled[i] = pixel i has valid RGB (originally opaque, or filled this run).
+    filled = bytearray(width * height)
+    any_transparent = False
+    for p in range(width * height):
+        if buf[p * 4 + 3] != 0:
+            filled[p] = 1
+        else:
+            any_transparent = True
+    if not any_transparent:
+        return bytes(buf)
+
+    neighbors = ((-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (1, -1), (-1, 1), (1, 1))
+    # Bound the passes so a fully/mostly transparent image can't loop forever.
+    max_passes = max(width, height)
+    for _ in range(max_passes):
+        newly = []
+        for y in range(height):
+            row = y * width
+            for x in range(width):
+                p = row + x
+                if filled[p]:
+                    continue
+                rs = gs = bs = cnt = 0
+                for dx, dy in neighbors:
+                    nx, ny = x + dx, y + dy
+                    if 0 <= nx < width and 0 <= ny < height:
+                        np = ny * width + nx
+                        if filled[np]:
+                            o = np * 4
+                            rs += buf[o]; gs += buf[o + 1]; bs += buf[o + 2]; cnt += 1
+                if cnt:
+                    o = p * 4
+                    buf[o] = rs // cnt; buf[o + 1] = gs // cnt; buf[o + 2] = bs // cnt
+                    newly.append(p)
+        if not newly:
+            break
+        for p in newly:
+            filled[p] = 1
+    return bytes(buf)
+
+
 def _compress_level(rgba, width, height, fmt, compressor):
-    """Compress a single mip level."""
+    """Compress a single mip level. RGBA is expected to be already edge-extended
+    (see _alpha_bleed, applied once up-front in rgba_to_tex_data)."""
     if fmt == FMT_BGRA8:
         return _rgba_to_bgra(rgba, width, height)
     else:


### PR DESCRIPTION
## Problem
Cutout / alpha-tested textures (bushes, foliage) exported a **white halo** around their edges.

**Cause:** fully-transparent pixels keep their (often white in GIMP) RGB. BC1/BC3 averages RGB across each 4x4 block (including those transparent-but-white pixels) and Lanczos mipmap downsampling mixes them in too, so white bled along the cutout edges. There was no alpha-bleed / edge-extend step before compression.

## Fix
Edge-extend (alpha bleed) the RGBA **once up-front** in rgba_to_tex_data, before compression **and** before mipmap downsampling: each transparent pixel'''s RGB is filled from the nearest opaque neighbor via a multi-pass flood. **Alpha is untouched** (cutouts stay crisp).

Implemented in all paths:
- **tex_core.py** - pure-Python flood (_alpha_bleed), applied in rgba_to_tex_data (works with or without the DLL).
- **dxt_compress.c** - native alpha_bleed() export (fast path).
- **dxt_compress.py** - binds + prefers native alpha_bleed, falls back to Python.

## Verification
- Built libdxtcompress.dll (MinGW gcc); C compiles clean; DLL loads under GIMP'''s Python 2.7 and exports alpha_bleed.
- End-to-end: a transparent-white edge pixel round-trips through bleed -> BC3 -> decompress as the **bled color, not white**, with **alpha still 0**.
- Both .py files compile under Python 2.7 (GIMP 2.10) and Python 3; tested installed in GIMP 2.10.

## Note
Rebuild the DLL (gcc -shared -O3 -o libdxtcompress.dll dxt_compress.c) for the native fast path; the Python path works without it.